### PR TITLE
fix: GitHub links in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,8 +34,8 @@ classifiers = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/uberspace/django-aetos"
-Issues = "https://github.com/uberspace/django-aetos/issues"
+Homepage = "https://github.com/uberspace/django_aetos"
+Issues = "https://github.com/uberspace/django_aetos/issues"
 
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "example_project.settings"


### PR DESCRIPTION
Links back to GitHub from PyPI are broken.